### PR TITLE
typo 'sring' fixed

### DIFF
--- a/src/core/string_id_converters.c
+++ b/src/core/string_id_converters.c
@@ -13,7 +13,7 @@ static const char* file_data_types[NUM_NETWORK_TEST_DATATYPES+1]=
 };
 
 
-const char* file_data_type_to_sring(const int data_type)
+const char* file_data_type_to_string(const int data_type)
 {
     if((data_type>0)&&(data_type<=NUM_NETWORK_TEST_DATATYPES))
         return file_data_types[data_type];

--- a/src/core/string_id_converters.h
+++ b/src/core/string_id_converters.h
@@ -35,7 +35,7 @@ extern "C"
 #endif
 
 
-extern const char *file_data_type_to_sring(const int data_type);
+extern const char *file_data_type_to_string(const int data_type);
 extern int get_test_type(const char *str);
 extern int get_test_type_name(int test_type,char *str);
 


### PR DESCRIPTION
В коде присутствовала опечатка, которая мешала компиляции (в /src/core/string_id_converters.c и /src/core/string_id_converters.h была объявлена функция file_data_type_to_sring, а в других файлах упоминалась file_data_type_to_string)